### PR TITLE
Move EXTRA_CXX_FLAGS outside remake_project()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 2.6)
+SET(CMAKE_CXX_FLAGS "-std=c++11" CACHE STRING "" FORCE)
 
 include(ReMake)
 
@@ -15,7 +16,6 @@ remake_project(
   PREFIX seekthermal-
   INSTALL /usr
   HEADER_DESTINATION include/seekthermal
-  EXTRA_CXX_FLAGS -std=c++11
 )
 
 remake_component(


### PR DESCRIPTION
Apparently ReMake ignores the EXTRA_CXX_FLAGS defined inside remake_project(...). To temporary fix the issues, I suggest declaring the flags following the standard Cmake approach.